### PR TITLE
Added initial schemas, openapi and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It includes:
 
 ## Repository structure
 
-- `specs/offchain/openapi.yaml`: OpenAPI 3.0 specification covering Get Quote and Submit Intent endpoints
+- `specs/openapi.yaml`: OpenAPI 3.0 specification covering Get Quote and Submit Intent endpoints
 - `schemas/typescript/get-quote.ts`: TypeScript interfaces for Get Quote request/response
 - `schemas/typescript/intent.ts`: TypeScript interfaces for Submit Intent request/response
 - `docs/references.md`: Curated external references to related off-chain APIs and intent protocols
@@ -21,7 +21,7 @@ This repository defines two endpoints:
 - Get Quote: quote generation for requested outputs based on available inputs
 - Submit Intent: submit a previously quoted, signed order for execution
 
-Authoritative schema: `specs/offchain/openapi.yaml`
+Authoritative schema: `specs/openapi.yaml`
 
 TypeScript-friendly interfaces are provided in `schemas/typescript/`:
 
@@ -32,9 +32,7 @@ TypeScript-friendly interfaces are provided in `schemas/typescript/`:
 
 Use any of the following online viewers. After this repo is public, you can point them directly to the raw `openapi.yaml` URL; until then, copy-paste the YAML content into the viewer.
 
-- Swagger Editor: open `https://editor.swagger.io/` and paste the contents of `specs/offchain/openapi.yaml`.
-- Redocly Viewer: open `https://redocly.github.io/redoc/` and use the URL parameter once hosted, for example `https://redocly.github.io/redoc/?url=RAW_OPENAPI_YAML_URL`.
-- Swagger UI Live: open `https://petstore.swagger.io/` and use the URL parameter once hosted, for example `https://petstore.swagger.io/?url=RAW_OPENAPI_YAML_URL`.
+- Swagger Editor: open `https://editor.swagger.io/` and paste the contents of `specs/openapi.yaml`.
 
 No local server is required.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# oif-specifications
+### OIF Specifications
+
+This repository is the canonical, versioned source of truth for OIF protocol standards and specifications.
+
+It includes:
+- Off-chain API standards for Get Quote and Submit Intent
+- Machine-readable OpenAPI schemas
+- Language-friendly TypeScript interfaces for client/server implementation
+
+## Repository structure
+
+- `specs/offchain/openapi.yaml`: OpenAPI 3.0 specification covering Get Quote and Submit Intent endpoints
+- `schemas/typescript/get-quote.ts`: TypeScript interfaces for Get Quote request/response
+- `schemas/typescript/intent.ts`: TypeScript interfaces for Submit Intent request/response
+- `docs/references.md`: Curated external references to related off-chain APIs and intent protocols
+
+## Off-chain API standards
+
+This repository defines two off-chain endpoints:
+
+- Get Quote: quote generation for requested outputs based on available inputs
+- Submit Intent: submit a previously quoted, signed order for execution
+
+Authoritative schema: `specs/offchain/openapi.yaml`
+
+TypeScript-friendly interfaces are provided in `schemas/typescript/`:
+
+- `schemas/typescript/get-quote.ts`
+- `schemas/typescript/intent.ts`
+
+## How to view the OpenAPI without running anything locally
+
+Use any of the following online viewers. After this repo is public, you can point them directly to the raw `openapi.yaml` URL; until then, copy-paste the YAML content into the viewer.
+
+- Swagger Editor: open `https://editor.swagger.io/` and paste the contents of `specs/offchain/openapi.yaml`.
+- Redocly Viewer: open `https://redocly.github.io/redoc/` and use the URL parameter once hosted, for example `https://redocly.github.io/redoc/?url=RAW_OPENAPI_YAML_URL`.
+- Swagger UI Live: open `https://petstore.swagger.io/` and use the URL parameter once hosted, for example `https://petstore.swagger.io/?url=RAW_OPENAPI_YAML_URL`.
+
+No local server is required.
+
+## Versioning
+
+The specs follow semantic versioning at the file level. Backwards-compatible changes (additive fields) will increment the minor version via Git tags/releases. Breaking changes will increment the major version. See Git history and release notes for details.
+
+## Contributing
+
+- Propose changes via pull request with rationale and, where applicable, example payloads.
+- Keep OpenAPI and TypeScript interfaces in sync.
+- Favor explicit types and self-explanatory naming. Avoid ambiguous or protocol-specific jargon without a definition.
+
+## License
+
+This repository is licensed under the terms of the `LICENSE` file at the root of the repository.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository is the canonical, versioned source of truth for OIF protocol standards and specifications.
 
 It includes:
-- Off-chain API standards for Get Quote and Submit Intent
+- API standards for Get Quote and Submit Intent
 - Machine-readable OpenAPI schemas
 - Language-friendly TypeScript interfaces for client/server implementation
 
@@ -14,9 +14,9 @@ It includes:
 - `schemas/typescript/intent.ts`: TypeScript interfaces for Submit Intent request/response
 - `docs/references.md`: Curated external references to related off-chain APIs and intent protocols
 
-## Off-chain API standards
+## API standards
 
-This repository defines two off-chain endpoints:
+This repository defines two endpoints:
 
 - Get Quote: quote generation for requested outputs based on available inputs
 - Submit Intent: submit a previously quoted, signed order for execution

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,19 +1,19 @@
-### External references: related off-chain APIs and intent protocols
+### External references: related APIs and intent protocols
 
-Below is a curated list of external APIs and docs that are relevant to OIF's off-chain quote and intent standards. These are for inspiration and comparison; they are not normative for OIF.
+Below is a curated list of external APIs and docs that are relevant to OIF's quote and intent standards. These are for inspiration and comparison; they are not normative for OIF.
 
 - Across Protocol — API Reference: `https://docs.across.to/reference/api-reference#api-endpoints`
   - Focus: cross-chain bridge quotes, relays, fees and ETA
   - Relevance: quote semantics, response fields (validity, fees, timing)
   
 - CoW Protocol — Orderbook API: `https://docs.cow.fi/cow-protocol/reference/apis/orderbook`
-  - Focus: off-chain orderbook, EIP-712 signing, solver-based settlement
-  - Relevance: off-chain orders, typed data, quote-to-order lifecycle
+  - Focus: orderbook API, EIP-712 signing, solver-based settlement
+  - Relevance: signed orders, typed data, quote-to-order lifecycle
 
 
 - Relay — Get Quote API: `https://docs.relay.link/references/api/get-quote`
   - Focus: cross-chain quote retrieval for intents
-  - Relevance: off-chain quoting, provider identity, validity windows
+  - Relevance: quoting, provider identity, validity windows
 
 - Stargate — Transfer Quotes API: `https://docs.stargate.finance/developers/api-docs/transfer-quotes`
   - Focus: bridging transfer quotes

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,25 @@
+### External references: related off-chain APIs and intent protocols
+
+Below is a curated list of external APIs and docs that are relevant to OIF's off-chain quote and intent standards. These are for inspiration and comparison; they are not normative for OIF.
+
+- Across Protocol — API Reference: `https://docs.across.to/reference/api-reference#api-endpoints`
+  - Focus: cross-chain bridge quotes, relays, fees and ETA
+  - Relevance: quote semantics, response fields (validity, fees, timing)
+  
+- CoW Protocol — Orderbook API: `https://docs.cow.fi/cow-protocol/reference/apis/orderbook`
+  - Focus: off-chain orderbook, EIP-712 signing, solver-based settlement
+  - Relevance: off-chain orders, typed data, quote-to-order lifecycle
+
+
+- Relay — Get Quote API: `https://docs.relay.link/references/api/get-quote`
+  - Focus: cross-chain quote retrieval for intents
+  - Relevance: off-chain quoting, provider identity, validity windows
+
+- Stargate — Transfer Quotes API: `https://docs.stargate.finance/developers/api-docs/transfer-quotes`
+  - Focus: bridging transfer quotes
+  - Note: may be less aligned with generic intent flows but useful for quoting patterns
+
+- LI.FI Catalyst — Intents API: reference link pending
+  - If you have a canonical public URL, please open a PR to add it here.
+
+

--- a/schemas/typescript/get-quote.ts
+++ b/schemas/typescript/get-quote.ts
@@ -1,0 +1,160 @@
+/*
+ * Off-chain Quote API TypeScript interfaces
+ * These interfaces model the request/response payloads for the OIF Get Quote API.
+ */
+
+export type Address = string; // ERC-7930 interoperable address
+
+export interface AssetLockReference {
+  kind: 'the-compact' | 'rhinestone';
+  params?: unknown;
+}
+
+export interface AvailableInput {
+  user: Address;
+  asset: Address;
+  amount: bigint;
+  /** If undefined, the asset is not locked and needs to be escrowed. */
+  lock?: AssetLockReference;
+}
+
+export interface RequestedOutputRequest {
+  /** The recipient of the output asset. */
+  receiver: Address;
+  asset: Address;
+  amount: bigint;
+  /** Optional calldata describing how the receiver will consume the output. */
+  calldata?: string;
+}
+
+export interface RequestedOutputDetails {
+  /** The user associated to the output (mirrors response shape). */
+  user: Address;
+  asset: Address;
+  amount: bigint;
+  calldata?: string;
+}
+
+export type QuotePreference =
+  | 'price'
+  | 'speed'
+  | 'input-priority'
+  | 'trust-minimization';
+
+export interface GetQuoteRequest {
+  user: Address;
+  /** Order of inputs is significant if preference is 'input-priority'. */
+  availableInputs: AvailableInput[];
+  requestedOutputs: RequestedOutputRequest[];
+  /** Minimum validity timestamp (seconds). */
+  minValidUntil?: number;
+  preference?: QuotePreference;
+}
+
+export interface Eip712Order {
+  /** Address-like identifier for the domain separator (ERC-7930 interoperable). */
+  domain: Address;
+  primaryType: string;
+  /** Message to be signed and submitted back. */
+  message: Record<string, unknown>;
+}
+
+export interface QuoteDetails {
+  requestedOutputs: RequestedOutputDetails[];
+  availableInputs: Array<
+    {
+      user: Address;
+      asset: Address;
+      amount: bigint;
+      /** If empty, the asset needs to be escrowed. */
+      lockType?: 'the-compact';
+      // TODO: include lock info structure when standardized across providers
+    }
+  >;
+}
+
+export interface Quote {
+  /** One or more EIP-712 compliant orders. */
+  orders: Eip712Order[];
+  details: QuoteDetails;
+  /** Quote validity timestamp (seconds). */
+  validUntil?: number;
+  /** Estimated time of arrival (seconds). */
+  eta?: number;
+  quoteId: string;
+  provider: string;
+}
+
+export interface GetQuoteResponse {
+  quotes: Quote[];
+}
+
+/*
+  Off-chain Get Quote interfaces for OIF protocol.
+  These interfaces mirror the OpenAPI schema in specs/offchain/openapi.yaml.
+*/
+
+export type Address7930 = string; // erc-7930 interoperable address
+
+export interface AssetLock {
+  /** If omitted, asset is not locked and needs to be escrowed */
+  kind: 'the-compact' | 'rhinestone';
+  /** Parameters depend on lock kind (e.g., lockTag for the-compact) */
+  params?: unknown;
+}
+
+export interface GetQuoteRequest {
+  user: Address7930;
+  /** Order of inputs is significant if preference is 'input-priority' */
+  availableInputs: Array<{
+    user: Address7930;
+    asset: Address7930;
+    amount: bigint;
+    lock?: AssetLock; // If undefined, asset is not locked and needs to be escrowed
+  }>; 
+  requestedOutputs: Array<{
+    receiver: Address7930;
+    asset: Address7930;
+    amount: bigint;
+    /** Optional execution data, interface TBD */
+    calldata?: string;
+  }>;
+  minValidUntil?: number;
+  preference?: 'price' | 'speed' | 'input-priority' | 'trust-minimization';
+}
+
+export interface EIP712OrderEnvelope {
+  /** Full EIP-712 compliant order payload */
+  domain: string; // erc-7930 interoperable address for domain separator owner/authority
+  primaryType: string;
+  message: Record<string, unknown>; // to be signed and submitted back
+}
+
+export interface GetQuoteResponseQuoteDetails {
+  requestedOutputs: Array<{
+    user: Address7930;
+    asset: Address7930;
+    amount: bigint;
+    calldata?: string;
+  }>;
+  availableInputs: Array<{
+    user: Address7930;
+    asset: Address7930;
+    amount: bigint;
+    /** If omitted, the asset needs to be escrowed */
+    lockType?: 'the-compact';
+  }>;
+}
+
+export interface GetQuoteResponse {
+  quotes: Array<{
+    orders: EIP712OrderEnvelope[];
+    details: GetQuoteResponseQuoteDetails;
+    validUntil?: number;
+    eta?: number;
+    quoteId: string;
+    provider: string;
+  }>;
+}
+
+

--- a/schemas/typescript/get-quote.ts
+++ b/schemas/typescript/get-quote.ts
@@ -1,5 +1,5 @@
 /*
- * Off-chain Quote API TypeScript interfaces
+ * Quote API TypeScript interfaces
  * These interfaces model the request/response payloads for the OIF Get Quote API.
  */
 

--- a/schemas/typescript/intent.ts
+++ b/schemas/typescript/intent.ts
@@ -1,0 +1,45 @@
+/*
+ * Off-chain Intent Submission API TypeScript interfaces
+ */
+
+export interface IntentRequest {
+  /** EIP-712 typed data for a gasless cross-chain order. */
+  order: Record<string, unknown>;
+  /** Signature corresponding to the EIP-712 order. */
+  signature: Record<string, unknown>;
+  /** Optional quote identifier from a prior Get Quote response. */
+  quoteId?: string;
+  /** Provider identifier. */
+  provider: string;
+}
+
+export interface IntentResponse {
+  /** Assigned order identifier if accepted. */
+  orderId?: string;
+  /** Human/machine readable status string. */
+  status: string;
+  /** Optional message for additional details on status. */
+  message?: string;
+}
+
+/*
+  Off-chain Submit Intent interfaces for OIF protocol.
+  These interfaces mirror the OpenAPI schema in specs/offchain/openapi.yaml.
+*/
+
+export interface IntentRequest {
+  /** GaslessCrossChainOrder or equivalent envelope */
+  order: Record<string, unknown>;
+  /** EIP-712 signature or equivalent */
+  signature: Record<string, unknown>;
+  quoteId?: string;
+  provider: string;
+}
+
+export interface IntentResponse {
+  orderId?: string;
+  status: string;
+  message?: string;
+}
+
+

--- a/schemas/typescript/intent.ts
+++ b/schemas/typescript/intent.ts
@@ -1,5 +1,5 @@
 /*
- * Off-chain Intent Submission API TypeScript interfaces
+ * Intent Submission API TypeScript interfaces
  */
 
 export interface IntentRequest {

--- a/specs/offchain/openapi.yaml
+++ b/specs/offchain/openapi.yaml
@@ -1,0 +1,242 @@
+openapi: 3.0.0
+info:
+  title: OIF Off-chain API
+  version: 0.1.0
+  description: |
+    Off-chain API specifications for OIF protocol covering quote generation and intent submission.
+    Amount fields are strings representing integers (e.g., uint256) to preserve precision across transports.
+servers:
+  - url: https://api.example.com
+tags:
+  - name: quote
+    description: Quote generation
+  - name: intent
+    description: Intent submission
+paths:
+  /offchain/v1/get-quote:
+    post:
+      tags: [quote]
+      summary: Get Quote
+      description: Generate executable quotes for requested outputs given available inputs.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetQuoteRequest'
+      responses:
+        '200':
+          description: Quotes successfully generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetQuoteResponse'
+        '400':
+          description: Malformed request
+        '422':
+          description: Inputs cannot satisfy requested outputs
+  /offchain/v1/submit-intent:
+    post:
+      tags: [intent]
+      summary: Submit Intent
+      description: Submit a previously quoted, signed order for execution.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntentRequest'
+      responses:
+        '200':
+          description: Intent accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntentResponse'
+        '400':
+          description: Malformed request
+        '422':
+          description: Invalid signature or order
+
+components:
+  schemas:
+    Address:
+      type: string
+      description: ERC-7930 interoperable address
+
+    Amount:
+      type: string
+      description: Integer encoded as a string to preserve precision (e.g., uint256)
+      pattern: '^[0-9]+$'
+
+    AssetLockReference:
+      type: object
+      description: Reference to a lock in an off-chain or on-chain locking system
+      properties:
+        kind:
+          type: string
+          enum: [the-compact, rhinestone]
+        params:
+          description: Lock-specific parameters
+      required: [kind]
+
+    AvailableInput:
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/Address'
+        asset:
+          $ref: '#/components/schemas/Address'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        lock:
+          $ref: '#/components/schemas/AssetLockReference'
+      required: [user, asset, amount]
+
+    RequestedOutput:
+      type: object
+      properties:
+        receiver:
+          $ref: '#/components/schemas/Address'
+        asset:
+          $ref: '#/components/schemas/Address'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        calldata:
+          type: string
+          description: Optional calldata describing how the receiver will consume the output
+      required: [receiver, asset, amount]
+
+    RequestedOutputDetails:
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/Address'
+        asset:
+          $ref: '#/components/schemas/Address'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        calldata:
+          type: string
+      required: [user, asset, amount]
+
+    QuotePreference:
+      type: string
+      enum: [price, speed, input-priority, trust-minimization]
+
+    GetQuoteRequest:
+      type: object
+      properties:
+        user:
+          $ref: '#/components/schemas/Address'
+        availableInputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailableInput'
+          description: Order of inputs is significant if preference is 'input-priority'
+        requestedOutputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequestedOutput'
+        minValidUntil:
+          type: number
+          description: Minimum validity timestamp (seconds)
+        preference:
+          $ref: '#/components/schemas/QuotePreference'
+      required: [user, availableInputs, requestedOutputs]
+
+    Eip712Order:
+      type: object
+      description: EIP-712 typed data for execution
+      properties:
+        domain:
+          $ref: '#/components/schemas/Address'
+        primaryType:
+          type: string
+        message:
+          type: object
+          additionalProperties: true
+      required: [domain, primaryType, message]
+
+    QuoteDetails:
+      type: object
+      properties:
+        requestedOutputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequestedOutputDetails'
+        availableInputs:
+          type: array
+          items:
+            type: object
+            properties:
+              user:
+                $ref: '#/components/schemas/Address'
+              asset:
+                $ref: '#/components/schemas/Address'
+              amount:
+                $ref: '#/components/schemas/Amount'
+              lockType:
+                type: string
+                enum: [the-compact]
+                description: If empty, the asset needs to be escrowed
+            required: [user, asset, amount]
+      required: [requestedOutputs, availableInputs]
+
+    Quote:
+      type: object
+      properties:
+        orders:
+          type: array
+          items:
+            $ref: '#/components/schemas/Eip712Order'
+        details:
+          $ref: '#/components/schemas/QuoteDetails'
+        validUntil:
+          type: number
+          description: Quote validity timestamp (seconds)
+        eta:
+          type: number
+          description: Estimated time of arrival (seconds)
+        quoteId:
+          type: string
+        provider:
+          type: string
+      required: [orders, details, quoteId, provider]
+
+    GetQuoteResponse:
+      type: object
+      properties:
+        quotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Quote'
+      required: [quotes]
+
+    IntentRequest:
+      type: object
+      properties:
+        order:
+          type: object
+          additionalProperties: true
+          description: EIP-712 typed data for a gasless cross-chain order
+        signature:
+          type: object
+          additionalProperties: true
+        quoteId:
+          type: string
+        provider:
+          type: string
+      required: [order, signature, provider]
+
+    IntentResponse:
+      type: object
+      properties:
+        orderId:
+          type: string
+          description: Assigned order identifier if accepted
+        status:
+          type: string
+        message:
+          type: string
+      required: [status]

--- a/specs/offchain/openapi.yaml
+++ b/specs/offchain/openapi.yaml
@@ -35,9 +35,7 @@ paths:
           description: Inputs cannot satisfy requested outputs
   /offchain/v1/submit-intent:
     post:
-      tags: [intent]
-      summary: Submit Intent
-      description: Submit a previously quoted, signed order for execution.
+      summary: Submit a previously quoted, signed order for execution.
       requestBody:
         required: true
         content:

--- a/specs/offchain/openapi.yaml
+++ b/specs/offchain/openapi.yaml
@@ -15,9 +15,7 @@ tags:
 paths:
   /offchain/v1/get-quote:
     post:
-      tags: [quote]
-      summary: Get Quote
-      description: Generate executable quotes for requested outputs given available inputs.
+      summary: Generate executable quotes for requested outputs given available inputs.
       requestBody:
         required: true
         content:

--- a/specs/offchain/openapi.yaml
+++ b/specs/offchain/openapi.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.0
 info:
-  title: OIF Off-chain API
+  title: OIF API
   version: 0.1.0
   description: |
-    Off-chain API specifications for OIF protocol covering quote generation and intent submission.
+    API specifications for OIF protocol covering quote generation and intent submission.
     Amount fields are strings representing integers (e.g., uint256) to preserve precision across transports.
 servers:
   - url: https://api.example.com
@@ -13,7 +13,7 @@ tags:
   - name: intent
     description: Intent submission
 paths:
-  /offchain/v1/get-quote:
+  /v1/get-quote:
     post:
       summary: Generate executable quotes for requested outputs given available inputs.
       requestBody:
@@ -33,7 +33,7 @@ paths:
           description: Malformed request
         '422':
           description: Inputs cannot satisfy requested outputs
-  /offchain/v1/submit-intent:
+  /v1/submit-intent:
     post:
       summary: Submit a previously quoted, signed order for execution.
       requestBody:
@@ -67,7 +67,7 @@ components:
 
     AssetLockReference:
       type: object
-      description: Reference to a lock in an off-chain or on-chain locking system
+      description: Reference to a lock in a locking system
       properties:
         kind:
           type: string

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -236,3 +236,5 @@ components:
         message:
           type: string
       required: [status]
+
+


### PR DESCRIPTION
Introduced structured OIF off-chain API specs, TypeScript interfaces, and documentation.

Added docs/references.md with curated links (Across, CoW, Relay, Stargate) and a placeholder for LI.FI Catalyst.
